### PR TITLE
Selectively process C includes recursively and CutsceneData type hack

### DIFF
--- a/asm_processor.py
+++ b/asm_processor.py
@@ -702,7 +702,7 @@ class GlobalAsmBlock:
                 })
         return src, fn
 
-cutscene_data_regexpr = re.compile(r"(CutsceneData (.|\n)*\[\] = {)")
+cutscene_data_regexpr = re.compile(r"CutsceneData (.|\n)*\[\] = {")
 float_regexpr = re.compile(r"[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?f")
 
 def repl_float_hex(m):

--- a/asm_processor.py
+++ b/asm_processor.py
@@ -7,6 +7,7 @@ import sys
 import re
 import os
 from collections import namedtuple
+from io import StringIO
 
 MAX_FN_SIZE = 100
 SLOW_CHECKS = False
@@ -701,6 +702,9 @@ class GlobalAsmBlock:
                 })
         return src, fn
 
+def repl_float_hex(m):
+    return str(struct.unpack(">I", struct.pack(">f", float(m.group(0).strip().rstrip("f"))))[0])
+
 def parse_source(f, opt, framepointer, input_enc, output_enc, print_source=None):
     if opt in ['O2', 'O1']:
         if framepointer:
@@ -733,6 +737,7 @@ def parse_source(f, opt, framepointer, input_enc, output_enc, print_source=None)
     state = GlobalState(min_instr_count, skip_instr_count, use_jtbl_for_rodata)
 
     global_asm = None
+    is_cutscene_data = False
     asm_functions = []
     output_lines = []
 
@@ -769,15 +774,38 @@ def parse_source(f, opt, framepointer, input_enc, output_enc, print_source=None)
                 output_lines[-1] = ''.join(src)
                 asm_functions.append(fn)
                 global_asm = None
+            elif ((line.startswith('#include "')) and line.endswith('" EARLY')):
+                # C includes qualified with EARLY (i.e. #include "file.c" EARLY) will be
+                # processed recursively when encountered.
+                fpath = os.path.dirname(f.name)
+                fname = line[line.index(' ') + 2 : -7]
+                include_src = StringIO()
+                with open(fpath + os.path.sep + fname, encoding=input_enc) as include_file:
+                    parse_source(include_file, opt, framepointer, input_enc, output_enc, include_src)
+                output_lines[-1] = include_src.getvalue()
+                include_src.write('#line ' + str(line_no) + '\n')
+                include_src.close()
             else:
+                # This is a hack to replace all floating-point numbers in an array of a particular type
+                # (in this case CutsceneData) with their corresponding IEEE-754 hexadecimal representation
+                if re.compile(r"(CutsceneData (.|\n)*\[\] = {)").search(line) is not None:
+                    is_cutscene_data = True
+                elif line.endswith("};"):
+                    is_cutscene_data = False
+                if is_cutscene_data:
+                    raw_line = re.sub(re.compile(r"[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?f"), repl_float_hex, raw_line)
                 output_lines[-1] = raw_line
 
     if print_source:
-        for line in output_lines:
-            print_source.write(line.encode(output_enc) + b'\n')
-        print_source.flush()
-        if print_source != sys.stdout.buffer:
-            print_source.close()
+        if isinstance(print_source, StringIO):
+            for line in output_lines:
+                print_source.write(line + '\n')
+        else:
+            for line in output_lines:
+                print_source.write(line.encode(output_enc) + b'\n')
+            print_source.flush()
+            if print_source != sys.stdout.buffer:
+                print_source.close()
 
     return asm_functions
 


### PR DESCRIPTION
- Allows C includes qualified with EARLY (i.e. #include "file.c" EARLY) to be recursively processed.
- Hack for arrays of CutsceneData type, converts floating-point numbers to their IEEE-754 hexadecimal representation as encountered.