### PR TITLE
Print information when encoding fails

### DIFF
--- a/asm_processor.py
+++ b/asm_processor.py
@@ -877,7 +877,14 @@ def parse_source(f, opt, framepointer, mips1, input_enc, output_enc, out_depende
                 print_source.write(line + '\n')
         else:
             for line in output_lines:
-                print_source.write(line.encode(output_enc) + b'\n')
+                try:
+                    line_encoded = line.encode(output_enc)
+                except UnicodeEncodeError:
+                    print("Failed to encode a line to", output_enc)
+                    print("The line:", line)
+                    print("The line, utf-8-encoded:", line.encode("utf-8"))
+                    raise
+                print_source.write(line_encoded + b'\n')
             print_source.flush()
             if print_source != sys.stdout.buffer:
                 print_source.close()


### PR DESCRIPTION
Example output:

```sh
$ make
python3 tools/asm_processor/build.py tools/ido_recomp/linux/7.1/cc -- mips-linux-gnu-as -march=vr4300 -32 -Iinclude -- -c -G 0 -non_shared -Xfullwarn -Xcpluscomm -Iinclude -Isrc -Iassets -Ibuild -Wab,-r4300_mul -woff 649,838,712 -mips2 -O2 -o build/src/code/z_skin_matrix.o src/code/z_skin_matrix.c
Failed to encode a line to euc-jp
The line:  * Produces a rotation matrix using ZYX Tait–Bryan angles.
The line, utf-8-encoded: b' * Produces a rotation matrix using ZYX Tait\xe2\x80\x93Bryan angles.'
Traceback (most recent call last):
  File "tools/asm_processor/build.py", line 38, in <module>
    functions, deps = asm_processor.run(asmproc_flags, outfile=preprocessed_file)
  File "/home/dragorn421/oot64decomp/oot/tools/asm_processor/asm_processor.py", line 1282, in run
    return run_wrapped(argv, outfile, functions)
  File "/home/dragorn421/oot64decomp/oot/tools/asm_processor/asm_processor.py", line 1264, in run_wrapped
    functions = parse_source(f, opt=opt, framepointer=args.framepointer, mips1=args.mips1, input_enc=args.input_enc, output_enc=args.output_enc, out_dependencies=deps, print_source=outfile)
  File "/home/dragorn421/oot64decomp/oot/tools/asm_processor/asm_processor.py", line 881, in parse_source
    line_encoded = line.encode(output_enc)
UnicodeEncodeError: 'euc_jp' codec can't encode character '\u2013' in position 44: illegal multibyte sequence
Makefile:228: recipe for target 'build/src/code/z_skin_matrix.o' failed
make: *** [build/src/code/z_skin_matrix.o] Error 1
```