### PR TITLE
Add 'endlabel' to the list of ignored line prefixes

### DIFF
--- a/asm_processor.py
+++ b/asm_processor.py
@@ -576,7 +576,7 @@ class GlobalAsmBlock:
             self.text_glabels.append(line.split()[1])
         if not line:
             pass # empty line
-        elif line.startswith('glabel ') or (' ' not in line and line.endswith(':')):
+        elif line.startswith('glabel ') or line.startswith('endlabel ') or (' ' not in line and line.endswith(':')):
             pass # label
         elif line.startswith('.section') or line in ['.text', '.data', '.rdata', '.rodata', '.bss', '.late_rodata']:
             # section change


### PR DESCRIPTION
This allows users to add suffixes to their function assembly (e.g. .end) without affecting asm-processor when doing so.