### PR TITLE
Refactor build.py

### DIFF
--- a/asm_processor.py
+++ b/asm_processor.py
@@ -925,8 +925,6 @@ def parse_source(f, opt, framepointer, mips1, input_enc, output_enc, out_depende
                 print_source.write(line_encoded)
                 print_source.write(newline_encoded)
             print_source.flush()
-            if print_source != sys.stdout.buffer:
-                print_source.close()
 
     return asm_functions
 

--- a/asm_processor.py
+++ b/asm_processor.py
@@ -913,6 +913,7 @@ def parse_source(f, opt, framepointer, mips1, input_enc, output_enc, out_depende
             for line in output_lines:
                 print_source.write(line + '\n')
         else:
+            newline_encoded = "\n".encode(output_enc)
             for line in output_lines:
                 try:
                     line_encoded = line.encode(output_enc)
@@ -921,7 +922,8 @@ def parse_source(f, opt, framepointer, mips1, input_enc, output_enc, out_depende
                     print("The line:", line)
                     print("The line, utf-8-encoded:", line.encode("utf-8"))
                     raise
-                print_source.write(line_encoded + b'\n')
+                print_source.write(line_encoded)
+                print_source.write(newline_encoded)
             print_source.flush()
             if print_source != sys.stdout.buffer:
                 print_source.close()

--- a/build.py
+++ b/build.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import shlex
 import subprocess
 import tempfile
+import uuid
 import asm_processor
 
 # Boolean for debugging purposes
@@ -55,21 +56,21 @@ asmproc_flags += opt_flags + [str(in_file)]
 
 with tempfile.TemporaryDirectory(prefix="asm_processor") as tmpdirname:
     tmpdir_path = Path(tmpdirname)
-    preprocessed_path = tmpdir_path / "preprocessed.c"
+    preprocessed_filename = "preprocessed_" + uuid.uuid4().hex + ".c"
+    preprocessed_path = tmpdir_path / preprocessed_filename
 
     with preprocessed_path.open("wb") as f:
         functions, deps = asm_processor.run(asmproc_flags, outfile=f)
 
     if keep_preprocessed_files:
         import shutil
-        import uuid
 
         keep_output_dir = Path("./asm_processor_preprocessed")
         keep_output_dir.mkdir(parents=True, exist_ok=True)
 
         shutil.copy(
             preprocessed_path,
-            keep_output_dir / (in_file.stem + "__" + uuid.uuid4().hex + ".c"),
+            keep_output_dir / (in_file.stem + "_" + preprocessed_filename),
         )
 
     compile_cmdline = (

--- a/build.py
+++ b/build.py
@@ -73,7 +73,7 @@ with tempfile.TemporaryDirectory(prefix="asm_processor") as tmpdirname:
     compile_cmdline = (
         compiler
         + compile_args
-        + ["-I", in_dir, "-o", str(out_file), str(preprocessed_path)]
+        + ["-I", str(in_dir), "-o", str(out_file), str(preprocessed_path)]
     )
 
     try:

--- a/build.py
+++ b/build.py
@@ -6,6 +6,8 @@ import subprocess
 import tempfile
 import asm_processor
 
+# Boolean for debugging purposes
+# Preprocessed files are temporary, set to True to keep a copy
 keep_preprocessed_files = False
 
 dir_path = Path(__file__).resolve().parent

--- a/build.py
+++ b/build.py
@@ -1,41 +1,45 @@
 #!/usr/bin/env python3
 import sys
-import os
+from pathlib import Path
 import shlex
 import subprocess
 import tempfile
 import asm_processor
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
-prelude = os.path.join(dir_path, "prelude.inc")
+dir_path = Path(__file__).resolve().parent
+asm_prelude_path = dir_path / "prelude.inc"
 
 all_args = sys.argv[1:]
-sep0 = [index for index, arg in enumerate(all_args) if not arg.startswith("-")][0]
+sep0 = next(index for index, arg in enumerate(all_args) if not arg.startswith("-"))
 sep1 = all_args.index("--")
 sep2 = all_args.index("--", sep1 + 1)
 
 asmproc_flags = all_args[:sep0]
 compiler = all_args[sep0:sep1]
 
-assembler = all_args[sep1 + 1 : sep2]
-assembler_sh = " ".join(shlex.quote(x) for x in assembler)
+assembler_args = all_args[sep1 + 1 : sep2]
+assembler_sh = " ".join(shlex.quote(x) for x in assembler_args)
+
 
 compile_args = all_args[sep2 + 1 :]
-in_file = compile_args[-1]
-out_ind = compile_args.index("-o")
-out_file = compile_args[out_ind + 1]
+
+in_file = Path(compile_args[-1])
 del compile_args[-1]
+
+out_ind = compile_args.index("-o")
+out_file = Path(compile_args[out_ind + 1])
 del compile_args[out_ind + 1]
 del compile_args[out_ind]
 
-in_dir = os.path.split(os.path.realpath(in_file))[0]
+
+in_dir = in_file.resolve().parent
 opt_flags = [
-    x for x in compile_args if x in ["-g3", "-g", "-O0", "-O1", "-O2", "-framepointer"]
+    x for x in compile_args if x in {"-g3", "-g", "-O0", "-O1", "-O2", "-framepointer"}
 ]
 if "-mips2" not in compile_args:
     opt_flags.append("-mips1")
 
-asmproc_flags += opt_flags + [in_file]
+asmproc_flags += opt_flags + [str(in_file)]
 
 # Drop .mdebug and .gptab sections from resulting binaries. This makes
 # resulting .o files much smaller and speeds up builds, but loses line
@@ -45,50 +49,49 @@ asmproc_flags += opt_flags + [in_file]
 # Convert encoding before compiling.
 # asmproc_flags += ["--input-enc", "utf-8", "--output-enc", "euc-jp"]
 
-preprocessed_file = tempfile.NamedTemporaryFile(
-    prefix="preprocessed", suffix=".c", delete=False
-)
+with tempfile.TemporaryDirectory(prefix="asm_processor") as tmpdirname:
+    tmpdir_path = Path(tmpdirname)
+    preprocessed_path = tmpdir_path / "preprocessed.c"
 
-try:
+    with preprocessed_path.open("wb") as f:
+        functions, deps = asm_processor.run(asmproc_flags, outfile=f)
+
     compile_cmdline = (
-        compiler + compile_args + ["-I", in_dir, "-o", out_file, preprocessed_file.name]
+        compiler
+        + compile_args
+        + ["-I", in_dir, "-o", str(out_file), str(preprocessed_path)]
     )
 
-    functions, deps = asm_processor.run(asmproc_flags, outfile=preprocessed_file)
     try:
         subprocess.check_call(compile_cmdline)
     except subprocess.CalledProcessError as e:
-        print("Failed to compile file " + in_file + ". Command line:")
+        print("Failed to compile file " + str(in_file) + ". Command line:")
         print()
         print(" ".join(shlex.quote(x) for x in compile_cmdline))
         print()
         sys.exit(55)
-        # To keep the preprocessed file:
-        # os._exit(1)
 
     asm_processor.run(
         asmproc_flags
         + [
             "--post-process",
-            out_file,
+            str(out_file),
             "--assembler",
             assembler_sh,
             "--asm-prelude",
-            prelude,
+            str(asm_prelude_path),
         ],
         functions=functions,
     )
 
-    deps_file = out_file[:-2] + ".asmproc.d"
+    deps_file = out_file.with_stem(".asmproc.d")
     if deps:
-        with open(deps_file, "w") as f:
-            f.write(out_file + ": " + " \\\n    ".join(deps) + "\n")
+        with deps_file.open("w") as f:
+            f.write(str(out_file) + ": " + " \\\n    ".join(deps) + "\n")
             for dep in deps:
                 f.write("\n" + dep + ":\n")
     else:
         try:
-            os.remove(deps_file)
+            deps_file.unlink(missing_ok=True)
         except OSError:
             pass
-finally:
-    os.remove(preprocessed_file.name)

--- a/build.py
+++ b/build.py
@@ -98,7 +98,7 @@ with tempfile.TemporaryDirectory(prefix="asm_processor") as tmpdirname:
         functions=functions,
     )
 
-    deps_file = out_file.with_stem(".asmproc.d")
+    deps_file = out_file.with_suffix(".asmproc.d")
     if deps:
         with deps_file.open("w") as f:
             f.write(str(out_file) + ": " + " \\\n    ".join(deps) + "\n")

--- a/build.py
+++ b/build.py
@@ -6,6 +6,8 @@ import subprocess
 import tempfile
 import asm_processor
 
+keep_preprocessed_files = False
+
 dir_path = Path(__file__).resolve().parent
 asm_prelude_path = dir_path / "prelude.inc"
 
@@ -55,6 +57,18 @@ with tempfile.TemporaryDirectory(prefix="asm_processor") as tmpdirname:
 
     with preprocessed_path.open("wb") as f:
         functions, deps = asm_processor.run(asmproc_flags, outfile=f)
+
+    if keep_preprocessed_files:
+        import shutil
+        import uuid
+
+        keep_output_dir = Path("./asm_processor_preprocessed")
+        keep_output_dir.mkdir(parents=True, exist_ok=True)
+
+        shutil.copy(
+            preprocessed_path,
+            keep_output_dir / (in_file.stem + "__" + uuid.uuid4().hex + ".c"),
+        )
 
     compile_cmdline = (
         compiler


### PR DESCRIPTION
I was investigating the depths of oot's build system and figured this file could use a slight refactoring pass

- possible bugfix in asm_processor.py (`b"\n"` isn't always the bytes for encoded `"\n"`)
- use `pathlib.Path`
- temporary file: use `TemporaryDirectory` as it is not guaranteed a `NamedTemporaryFile` can be read after being written (according to https://docs.python.org/3/library/tempfile.html?highlight=namedtemporaryfile#tempfile.NamedTemporaryFile it straight up doesn't work in Windows, and hopefully this helps with the random errors we occasionally have with temp files on oot's jenkins)
- possibility of copying preprocessed files to `./asm_processor_preprocessed` by hardcoding `keep_preprocessed_files` to True (default False)

I tested the changes on oot, works fine (after `EARLY` -> `#pragma asmproc recurse`)

(you can DM me or @ me anywhere, either zeldaret or decompals discord for example)