### PR TITLE
Add `jlabel` and `dlabel` to `prelude.inc`

### DIFF
--- a/asm_processor.py
+++ b/asm_processor.py
@@ -605,7 +605,7 @@ class GlobalAsmBlock:
         line = re.sub(r'^[a-zA-Z0-9_]+:\s*', '', line)
         changed_section = False
         emitting_double = False
-        if line.startswith('glabel ') and self.cur_section == '.text':
+        if (line.startswith('glabel ') or line.startswith('jlabel ')) and self.cur_section == '.text':
             self.text_glabels.append(line.split()[1])
         if not line:
             pass # empty line

--- a/asm_processor.py
+++ b/asm_processor.py
@@ -609,7 +609,7 @@ class GlobalAsmBlock:
             self.text_glabels.append(line.split()[1])
         if not line:
             pass # empty line
-        elif line.startswith('glabel ') or line.startswith('dlabel ') or line.startswith('endlabel ') or (' ' not in line and line.endswith(':')):
+        elif line.startswith('glabel ') or line.startswith('dlabel ') or line.startswith('jlabel ') or line.startswith('endlabel ') or (' ' not in line and line.endswith(':')):
             pass # label
         elif line.startswith('.section') or line in ['.text', '.data', '.rdata', '.rodata', '.bss', '.late_rodata']:
             # section change

--- a/prelude.inc
+++ b/prelude.inc
@@ -4,7 +4,6 @@
 
 .macro glabel label
     .global \label
-    .type \label, @function
     \label:
 .endm
 
@@ -14,7 +13,6 @@
 .endm
 
 .macro jlabel label
-    .global \label
     \label:
 .endm
 

--- a/prelude.inc
+++ b/prelude.inc
@@ -1,7 +1,19 @@
 .set noat
 .set noreorder
 .set gp=64
+
 .macro glabel label
+    .global \label
+    .type \label, @function
+    \label:
+.endm
+
+.macro dlabel label
+    .global \label
+    \label:
+.endm
+
+.macro jlabel label
     .global \label
     \label:
 .endm


### PR DESCRIPTION
Adds both `dlabel` and `jlabel` to `prelude.inc`

I also added an extra check in `asm_processor.py` for `jlabel` since it is already doing that check for `dlabel`, but I'm not sure if it is required