### PR TITLE
Add support to use INCLUDE_ASM/INCLUDE_RODATA in place of GLOBAL_ASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To compile the file, run `python3 build.py $CC -- $AS $ASFLAGS -- $CFLAGS -o out
 In addition to an .o file, build.py also generates a .d file with Makefile dependencies for .s files referenced by the input .c file.
 This functionality may be removed if not needed.
 
-Reading assembly from file is also supported, by either `GLOBAL_ASM("file.s")` or `#pragma GLOBAL_ASM("file.s")`.
+Reading assembly from file is also supported, by either `GLOBAL_ASM("file.s")`, `#pragma GLOBAL_ASM("file.s")`, `INCLUDE_ASM("folder", functionname);`, or `INCLUDE_RODATA("folder", functionname);` (note the `;` on the include macros are required).
 
 ### What is supported?
 

--- a/asm_processor.py
+++ b/asm_processor.py
@@ -965,7 +965,7 @@ def parse_source(f, opts, out_dependencies, print_source=None):
             start_index = len(output_lines)
         elif (((line.startswith('GLOBAL_ASM("') or line.startswith('#pragma GLOBAL_ASM("')) and (line.endswith('")')))
                 or ((line.startswith('INCLUDE_ASM("') or line.startswith('INCLUDE_RODATA("')) and line.endswith(');'))):
-            if line.startswith('INCLUDE_'): # INCLUDE macro format is INCLUDE_ASM(folderpath, functionname);
+            if line.startswith('INCLUDE_'): # INCLUDE macro format is INCLUDE_ASM("folder", functionname);
                 spline = line.split(',')
                 fname = spline[0][spline[0].index('(') + 2 : -1] + "/" + spline[1][1:-2] + '.s'
             else: # GLOBAL macro format is GLOBAL_ASM(filepath)

--- a/asm_processor.py
+++ b/asm_processor.py
@@ -968,7 +968,7 @@ def parse_source(f, opts, out_dependencies, print_source=None):
             if line.startswith('INCLUDE_'): # INCLUDE macro format is INCLUDE_ASM("folder", functionname);
                 spline = line.split(',')
                 fname = spline[0][spline[0].index('(') + 2 : -1] + "/" + spline[1][1:-2] + '.s'
-            else: # GLOBAL macro format is GLOBAL_ASM(filepath)
+            else: # GLOBAL macro format is GLOBAL_ASM("filepath")
                 fname = line[line.index('(') + 2 : -2]
             out_dependencies.append(fname)
             global_asm = GlobalAsmBlock(fname)

--- a/asm_processor.py
+++ b/asm_processor.py
@@ -960,12 +960,16 @@ def parse_source(f, opts, out_dependencies, print_source=None):
                 global_asm = None
             else:
                 global_asm.process_line(raw_line, output_enc)
-        elif line in ['GLOBAL_ASM(', '#pragma GLOBAL_ASM(']:
+        elif line in ['GLOBAL_ASM(', '#pragma GLOBAL_ASM(', 'INCLUDE_ASM(']:
             global_asm = GlobalAsmBlock("GLOBAL_ASM block at line " + str(line_no))
             start_index = len(output_lines)
-        elif ((line.startswith('GLOBAL_ASM("') or line.startswith('#pragma GLOBAL_ASM("'))
-                and line.endswith('")')):
-            fname = line[line.index('(') + 2 : -2]
+        elif (((line.startswith('GLOBAL_ASM("') or line.startswith('#pragma GLOBAL_ASM("')) and (line.endswith('")')))
+                or ((line.startswith('INCLUDE_ASM("') or line.startswith('INCLUDE_RODATA("')) and line.endswith(');'))):
+            if line.startswith('INCLUDE_'): # INCLUDE macro format is INCLUDE_ASM(folderpath, functionname);
+                spline = line.split(',')
+                fname = spline[0][spline[0].index('(') + 2 : -1] + "/" + spline[1][1:-2] + '.s'
+            else: # GLOBAL macro format is GLOBAL_ASM(filepath)
+                fname = line[line.index('(') + 2 : -2]
             out_dependencies.append(fname)
             global_asm = GlobalAsmBlock(fname)
             with open(fname, encoding=opts.input_enc) as f:


### PR DESCRIPTION
GCC decompilation projects tend to use `INCLUDE_ASM`/`INCLUDE_RODATA` macros to include their asm of unfinished functions. This adds support to use the same macros with IDO projects, and also allows adding GCC support earlier on in IDO projects as we can use the same macros.

I'll admit it is a bit of a mess, so if you have any ideas to clean it up I am all ears.

Note I have tested this a version of MM that adds GCC support, and it works fine.