### PR TITLE
Define `endlabel` in prelude.inc

### DIFF
--- a/asm_processor.py
+++ b/asm_processor.py
@@ -1096,14 +1096,14 @@ def fixup_objfile(objfile_name, functions, asm_prelude, assembler, output_enc, d
             for sectype, (temp_name, size) in function.data.items():
                 if temp_name is not None:
                     asm.append('.section ' + sectype)
-                    asm.append('dlabel ' + temp_name + '_asm_start')
+                    asm.append('glabel ' + temp_name + '_asm_start')
             asm.append('.text')
             for line in function.asm_conts:
                 asm.append(line)
             for sectype, (temp_name, size) in function.data.items():
                 if temp_name is not None:
                     asm.append('.section ' + sectype)
-                    asm.append('dlabel ' + temp_name + '_asm_end')
+                    asm.append('glabel ' + temp_name + '_asm_end')
     if any(late_rodata_asm):
         late_rodata_source_name_start = '_asmpp_late_rodata_start'
         late_rodata_source_name_end = '_asmpp_late_rodata_end'
@@ -1111,10 +1111,10 @@ def fixup_objfile(objfile_name, functions, asm_prelude, assembler, output_enc, d
         # Put some padding at the start to avoid conflating symbols with
         # references to the whole section.
         asm.append('.word 0, 0')
-        asm.append('dlabel {}'.format(late_rodata_source_name_start))
+        asm.append('glabel {}'.format(late_rodata_source_name_start))
         for conts in late_rodata_asm:
             asm.extend(conts)
-        asm.append('dlabel {}'.format(late_rodata_source_name_end))
+        asm.append('glabel {}'.format(late_rodata_source_name_end))
 
     o_file = tempfile.NamedTemporaryFile(prefix='asm-processor', suffix='.o', delete=False)
     o_name = o_file.name

--- a/asm_processor.py
+++ b/asm_processor.py
@@ -1096,14 +1096,14 @@ def fixup_objfile(objfile_name, functions, asm_prelude, assembler, output_enc, d
             for sectype, (temp_name, size) in function.data.items():
                 if temp_name is not None:
                     asm.append('.section ' + sectype)
-                    asm.append('glabel ' + temp_name + '_asm_start')
+                    asm.append('dlabel ' + temp_name + '_asm_start')
             asm.append('.text')
             for line in function.asm_conts:
                 asm.append(line)
             for sectype, (temp_name, size) in function.data.items():
                 if temp_name is not None:
                     asm.append('.section ' + sectype)
-                    asm.append('glabel ' + temp_name + '_asm_end')
+                    asm.append('dlabel ' + temp_name + '_asm_end')
     if any(late_rodata_asm):
         late_rodata_source_name_start = '_asmpp_late_rodata_start'
         late_rodata_source_name_end = '_asmpp_late_rodata_end'
@@ -1111,10 +1111,10 @@ def fixup_objfile(objfile_name, functions, asm_prelude, assembler, output_enc, d
         # Put some padding at the start to avoid conflating symbols with
         # references to the whole section.
         asm.append('.word 0, 0')
-        asm.append('glabel {}'.format(late_rodata_source_name_start))
+        asm.append('dlabel {}'.format(late_rodata_source_name_start))
         for conts in late_rodata_asm:
             asm.extend(conts)
-        asm.append('glabel {}'.format(late_rodata_source_name_end))
+        asm.append('dlabel {}'.format(late_rodata_source_name_end))
 
     o_file = tempfile.NamedTemporaryFile(prefix='asm-processor', suffix='.o', delete=False)
     o_name = o_file.name

--- a/prelude.inc
+++ b/prelude.inc
@@ -4,8 +4,6 @@
 
 .macro glabel label
     .global \label
-    .ent \label
-    .type \label, @function
     \label:
 .endm
 
@@ -19,8 +17,6 @@
 .endm
 
 .macro endlabel label
-    .end \label
-    .size \label,.-\label
 .endm
 
 # Float register aliases (o32 ABI, odd ones are rarely used)

--- a/prelude.inc
+++ b/prelude.inc
@@ -4,6 +4,8 @@
 
 .macro glabel label
     .global \label
+    .ent \label
+    .type \label, @function
     \label:
 .endm
 
@@ -16,6 +18,10 @@
     \label:
 .endm
 
+.macro endlabel label
+    .end \label
+    .size \label,.-\label
+.endm
 
 # Float register aliases (o32 ABI, odd ones are rarely used)
 


### PR DESCRIPTION
~~I was trying to use glabel to actually make functions to be marked as STT_FUNC on the built elf on MM, but only editing the stuff on MM's side I get tons of `/tmp/asm-processorxffpf4ge.s:287: Warning: missing .end` because of the generated asm from asm-proc.~~

~~A workaround is to use `dlabel`s instead of `glabel`s on the asm generated by asm-proc. This is totally a hack, lmk if you have a better solution.~~


