### PR TITLE
Update labels in prelude.inc

### DIFF
--- a/asm_processor.py
+++ b/asm_processor.py
@@ -613,7 +613,7 @@ class GlobalAsmBlock:
             self.text_glabels.append(line.split()[1])
         if not line:
             pass # empty line
-        elif line.startswith('glabel ') or line.startswith('dlabel ') or line.startswith('jlabel ') or line.startswith('alabel ') or line.startswith('endlabel ') or line.startswith('enddlabel ') or line.startswith('nmlabel ') or (' ' not in line and line.endswith(':')):
+        elif line.startswith('glabel ') or line.startswith('dlabel ') or line.startswith('jlabel ') or line.startswith('alabel ') or line.startswith('endlabel ') or line.startswith('enddlabel ') or line.startswith('nonmatching ') or (' ' not in line and line.endswith(':')):
             pass # label
         elif line.startswith('.section') or line in ['.text', '.data', '.rdata', '.rodata', '.bss', '.late_rodata']:
             # section change

--- a/asm_processor.py
+++ b/asm_processor.py
@@ -613,7 +613,7 @@ class GlobalAsmBlock:
             self.text_glabels.append(line.split()[1])
         if not line:
             pass # empty line
-        elif line.startswith('glabel ') or line.startswith('dlabel ') or line.startswith('jlabel ') or line.startswith('endlabel ') or (' ' not in line and line.endswith(':')):
+        elif line.startswith('glabel ') or line.startswith('dlabel ') or line.startswith('jlabel ') or line.startswith('alabel ') or line.startswith('endlabel ') or line.startswith('enddlabel ') or line.startswith('nmlabel ') or (' ' not in line and line.endswith(':')):
             pass # label
         elif line.startswith('.section') or line in ['.text', '.data', '.rdata', '.rodata', '.bss', '.late_rodata']:
             # section change

--- a/prelude.inc
+++ b/prelude.inc
@@ -40,7 +40,7 @@
 
 
 # Label to signal the symbol haven't been matched yet.
-.macro nmlabel label, size=1
+.macro nonmatching label, size=1
     .global \label\().NON_MATCHING
     .type \label\().NON_MATCHING, @object
     .size \label\().NON_MATCHING, \size

--- a/prelude.inc
+++ b/prelude.inc
@@ -2,21 +2,49 @@
 .set noreorder
 .set gp=64
 
-.macro glabel label
-    .global \label
+# A function symbol (but some projects use it for everything).
+.macro glabel label, visibility=global
+    .\visibility \label
     \label:
 .endm
 
-.macro dlabel label
-    .global \label
+# The end of a function symbol.
+.macro endlabel label
+    .size \label, . - \label
+.endm
+
+# An alternative entry to a function.
+.macro alabel label, visibility=global
+    .\visibility \label
+    .type \label, @function
     \label:
 .endm
 
+
+# A data symbol.
+.macro dlabel label, visibility=global
+    .\visibility \label
+    \label:
+.endm
+
+# End of a data symbol.
+.macro enddlabel label
+    .size \label, . - \label
+.endm
+
+
+# A label referenced by a jumptable.
 .macro jlabel label
     \label:
 .endm
 
-.macro endlabel label
+
+# Label to signal the symbol haven't been matched yet.
+.macro nmlabel label, size=1
+    .global \label\().NON_MATCHING
+    .type \label\().NON_MATCHING, @object
+    .size \label\().NON_MATCHING, \size
+    \label\().NON_MATCHING:
 .endm
 
 # Float register aliases (o32 ABI, odd ones are rarely used)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "asm-processor"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "argp",

--- a/rust/src/preprocess.rs
+++ b/rust/src/preprocess.rs
@@ -323,7 +323,10 @@ impl GlobalAsmBlock {
         } else if line.starts_with("glabel ")
             || line.starts_with("dlabel ")
             || line.starts_with("jlabel ")
+            || line.starts_with("alabel ")
             || line.starts_with("endlabel ")
+            || line.starts_with("enddlabel ")
+            || line.starts_with("nmlabel ")
             || (!line.contains(" ") && line.ends_with(":"))
         {
             // label

--- a/rust/src/preprocess.rs
+++ b/rust/src/preprocess.rs
@@ -326,7 +326,7 @@ impl GlobalAsmBlock {
             || line.starts_with("alabel ")
             || line.starts_with("endlabel ")
             || line.starts_with("enddlabel ")
-            || line.starts_with("nmlabel ")
+            || line.starts_with("nonmatching ")
             || (!line.contains(" ") && line.ends_with(":"))
         {
             // label


### PR DESCRIPTION
The next splat version (https://github.com/ethteck/splat/pull/466) will add and change the defaults for the label macros it uses, so this PR aims to update the macro definitions so projects using splat and asm-processor have minimal issues while updating to the latest version.

I tested the Python version with Yoshi's Story. I did not test the Rust version.

