### PR TITLE
Fix #35 : rust impl of mdebug relocation

### DIFF
--- a/rust/src/postprocess.rs
+++ b/rust/src/postprocess.rs
@@ -403,11 +403,11 @@ impl Section {
         relocate(hdrr.crfd, &mut hdrr.cb_rfd_offset);
         relocate(hdrr.iext_max, &mut hdrr.cb_ext_offset);
 
-        let mut new_data = [0; Hdrr::SIZE];
+        let mut new_data = self.data.clone();
         let mut cursor = Cursor::new(new_data.as_mut_slice());
         hdrr.write_options(&mut cursor, endian, ()).unwrap();
 
-        self.data = new_data.to_vec();
+        self.data = new_data;
     }
 }
 


### PR DESCRIPTION
Fixes #35

Fix courtesy of copilot. I am illiterate in Rust

<details>

prompt:

> this repo contains a python implementation in build.py and asm_processor.py, and a rust implementation in the rust/ folder
> 
> there is a bug with the rust implementation: it produces object files with an incomplete or corrupted mdebug
> 
> compare the two implementations and find the bug in the rust one

answer follows

--------

## Bug found

The Rust implementation corrupts `.mdebug` by discarding the section body when relocating it.

### Location
- postprocess.rs
- `Section::relocate_mdebug()`

### Problem
In Rust, this code:

```rust
let mut new_data = [0; Hdrr::SIZE];
let mut cursor = Cursor::new(new_data.as_mut_slice());
hdrr.write_options(&mut cursor, endian, ()).unwrap();

self.data = new_data.to_vec();
```

replaces the entire `.mdebug` section contents with only the `Hdrr` header bytes.

### Why it’s wrong
- The Python implementation preserves `self.data` and only patches the header fields:
  - reads full section bytes
  - updates offsets
  - writes header back into `new_data[0:0x60]`
  - keeps the rest of the section intact
- The Rust code instead truncates `self.data` to `Hdrr::SIZE` and loses all subsequent `.mdebug` data.

### Consequence
When `.mdebug` moves during rewrites, the Rust postprocessor leaves a truncated/corrupted `.mdebug` section, causing invalid object files.

### Fix
The Rust implementation should update only the first `Hdrr::SIZE` bytes of `self.data` instead of replacing the whole vector.

If you want, I can patch postprocess.rs to preserve the remaining `.mdebug` bytes.

</details>